### PR TITLE
Update JLL calling convention for executables

### DIFF
--- a/src/Mineos.jl
+++ b/src/Mineos.jl
@@ -168,8 +168,12 @@ function eigenmodes(m::LinearLayeredModel, freq=1.0;
                         """)
                 end
                 write_mineos(model_in, m, freq)
-                output = minos_bran() do minos_bran_path
-                    String(read(pipeline(control, `$minos_bran_path`)))
+                output = @static if VERSION < v"1.6"
+                    minos_bran() do minos_bran_path
+                        String(read(pipeline(control, `$minos_bran_path`)))
+                    end
+                else
+                    String(read(pipeline(control, `$(minos_bran())`)))
                 end
                 _check_minos_bran_stdout(output)
                 modes = read_eigenmodes(model_out)


### PR DESCRIPTION
JLLs produced with BinaryBuilder.jl have for a good while now had
a different recommended convention by which executable products
are called, for thread-safety.  Update the call to `minos_bran`
to reflect this on Julia versions below v1.6.
