### PR TITLE
Include DataStructures v0.19 in compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Mineos_jll = "77b29d01-de08-56f3-96c6-9f6f21a29421"
 SeisModels = "47bbc3d6-959e-5592-a00a-d17660d07a0f"
 
 [compat]
-DataStructures = "0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
+DataStructures = "0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 Mineos_jll = "1"
 SeisModels = "0.3.7, 1"
 julia = "1.3"


### PR DESCRIPTION
This packages continues to work with the major change from v0.18
to v0.19 of DataStructures, so bump compatibility.
